### PR TITLE
Multi arch builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,17 +24,11 @@ jobs:
     - name: Prepare checking latest kustomize release
       run: |
         docker build . -t line/kubectl-kustomize:kustomize-version --target latest-kustomize-version
-        docker build . -t line/kubectl-kustomize:kustomize-url --target latest-kustomize-download-url
     - name: Check latest kustomize version
       id: kustomize
       run: |
         if version=$(docker run line/kubectl-kustomize:kustomize-version); then
           echo ::set-output name=version::$version
-        else
-          exit 1
-        fi
-        if url=$(docker run line/kubectl-kustomize:kustomize-url); then
-          echo ::set-output name=url::$url
         else
           exit 1
         fi
@@ -54,34 +48,38 @@ jobs:
           echo $result
           exit 1;
         fi
-    - name: Build image
-      id: build
-      if: steps.image_existence.outputs.exists == 'false'
-      env:
-        IMAGE_TAG: ${{ steps.image_existence.outputs.tag }}
-        KUBECTL_VERSION: ${{ steps.kubectl.outputs.version }}
-        KUSTOMIZE_DOWNLOAD_URL: ${{ steps.kustomize.outputs.url }}
-      run: |
-        docker build . -t line/kubectl-kustomize:${IMAGE_TAG} \
-          --build-arg KUBECTL_VERSION=${KUBECTL_VERSION} \
-          --build-arg KUSTOMIZE_DOWNLOAD_URL=${KUSTOMIZE_DOWNLOAD_URL}
-        docker tag line/kubectl-kustomize:${IMAGE_TAG} line/kubectl-kustomize:latest
-        echo ::set-output name=tag::${IMAGE_TAG}
-    - name: Validate image
-      if: steps.build.outputs.tag
-      env:
-        IMAGE_TAG: ${{ steps.image_existence.outputs.tag }}
-      run: docker run --rm line/kubectl-kustomize:${IMAGE_TAG} -c "kubectl && kustomize"
+    # https://github.com/docker/setup-qemu-action
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    # https://github.com/docker/setup-buildx-action
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+    # List available platforms for buildx
+    - name: Available platforms
+      run: echo ${{ steps.buildx.outputs.platforms }}
+    # Build the image using buildx
     - name: Login to Docker Hub
-      if: steps.build.outputs.tag
-      uses: azure/docker-login@v1
+      uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-    - name: Push image
-      if: steps.build.outputs.tag
+    - name: Build and push
+      id: build
+      if: steps.image_existence.outputs.exists == 'false'
       env:
-        IMAGE_TAG: ${{ steps.build.outputs.tag }}
+        BUILDER_INSTANCE: ${{ steps.buildx.outputs.name }}
+        IMAGE_TAG: ${{ steps.image_existence.outputs.tag }}
+        KUBECTL_VERSION: ${{ steps.kubectl.outputs.version }}
+        KUSTOMIZE_VERSION: ${{ steps.kustomize.outputs.version }}
       run: |
-        docker push line/kubectl-kustomize:${IMAGE_TAG}
-        docker push line/kubectl-kustomize:latest
+        docker buildx build \
+          --builder ${BUILDER_INSTANCE} \
+          --tag line/kubectl-kustomize:${IMAGE_TAG} \
+          --tag line/kubectl-kustomize:latest \
+          --platform linux/amd64 \
+          --push \
+          --build-arg KUBECTL_VERSION=${KUBECTL_VERSION} \
+          --build-arg KUSTOMIZE_VERSION=${KUSTOMIZE_VERSION} \
+          .
+        echo ::set-output name=tag::${IMAGE_TAG}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,7 +87,7 @@ jobs:
           --builder ${BUILDER_INSTANCE} \
           --tag ${REPO_OWNER}/kubectl-kustomize:${IMAGE_TAG} \
           --tag ${REPO_OWNER}/kubectl-kustomize:latest \
-          --platform linux/amd64 \
+          --platform linux/amd64,linux/arm64 \
           --push \
           --build-arg KUBECTL_VERSION=${KUBECTL_VERSION} \
           --build-arg KUSTOMIZE_VERSION=${KUSTOMIZE_VERSION} \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,22 +12,30 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Prepare checking latest kubectl version
-      run: docker build . -t line/kubectl-kustomize:kubectl-version --target latest-kubectl-version
+      env:
+        REPO_OWNER: ${{github.repository_owner}}
+      run: docker build . -t ${REPO_OWNER}/kubectl-kustomize:kubectl-version --target latest-kubectl-version
     - name: Check latest kubectl version
       id: kubectl
+      env:
+        REPO_OWNER: ${{github.repository_owner}}
       run: |
-        if version=$(docker run line/kubectl-kustomize:kubectl-version); then
+        if version=$(docker run ${REPO_OWNER}/kubectl-kustomize:kubectl-version); then
           echo ::set-output name=version::$version
         else
           exit 1
         fi
     - name: Prepare checking latest kustomize release
+      env:
+        REPO_OWNER: ${{github.repository_owner}}
       run: |
-        docker build . -t line/kubectl-kustomize:kustomize-version --target latest-kustomize-version
+        docker build . -t ${REPO_OWNER}/kubectl-kustomize:kustomize-version --target latest-kustomize-version
     - name: Check latest kustomize version
       id: kustomize
+      env:
+        REPO_OWNER: ${{github.repository_owner}}
       run: |
-        if version=$(docker run line/kubectl-kustomize:kustomize-version); then
+        if version=$(docker run ${REPO_OWNER}/kubectl-kustomize:kustomize-version); then
           echo ::set-output name=version::$version
         else
           exit 1
@@ -36,10 +44,11 @@ jobs:
       id: image_existence
       env:
         IMAGE_TAG: ${{ format('{0}-{1}', steps.kubectl.outputs.version, steps.kustomize.outputs.version) }}
+        REPO_OWNER: ${{github.repository_owner}}
       shell: bash +e {0}
       run: |
         echo ::set-output name=tag::${IMAGE_TAG}
-        result="$(DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect line/kubectl-kustomize:${IMAGE_TAG} 2>&1)"
+        result="$(DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect ${REPO_OWNER}/kubectl-kustomize:${IMAGE_TAG} 2>&1)"
         if [[ $? -eq 0 ]]; then
           echo ::set-output name=exists::true
         elif [[ $result == *"no such manifest"* ]]; then
@@ -72,11 +81,12 @@ jobs:
         IMAGE_TAG: ${{ steps.image_existence.outputs.tag }}
         KUBECTL_VERSION: ${{ steps.kubectl.outputs.version }}
         KUSTOMIZE_VERSION: ${{ steps.kustomize.outputs.version }}
+        REPO_OWNER: ${{github.repository_owner}}
       run: |
         docker buildx build \
           --builder ${BUILDER_INSTANCE} \
-          --tag line/kubectl-kustomize:${IMAGE_TAG} \
-          --tag line/kubectl-kustomize:latest \
+          --tag ${REPO_OWNER}/kubectl-kustomize:${IMAGE_TAG} \
+          --tag ${REPO_OWNER}/kubectl-kustomize:latest \
           --platform linux/amd64 \
           --push \
           --build-arg KUBECTL_VERSION=${KUBECTL_VERSION} \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,7 @@ on:
     - master
   schedule:
   - cron: "0 */8 * * *"
+  workflow_dispatch: {}
 jobs:
   release:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
Some projects (such as Gatekeeper by Open-Policy-Agent) include this image to run apply template or labels to their running pods. Gatekeeper, at least, uses it to label pods after installing the helm chart.

However, Gatekeeper is a multi-arch project and it runs on arm64 hardware.

This PR adds multi-arch support for kubectl-kustomize to facilitate it's usage in other multi-arch projects like Gatekeeper.