### PR TITLE
Bump up alpine version to 3.14.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN set -ex; \
 
 
 # Runtime
-FROM alpine:3.13.5 AS runtime
+FROM alpine:3.14.3 AS runtime
 
 LABEL maintainer="LINE Open Source <dl_oss_dev@linecorp.com>"
 


### PR DESCRIPTION
## Background

https://alpinelinux.org/posts/Alpine-3.14.3-released.html

## Changes

This commit bumps up alpine version to 3.14.3 for making image up to date.