### PR TITLE
Use CMD/ENTRYPOINT of alpine for image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,6 @@ LABEL maintainer="LINE Open Source <dl_oss_dev@linecorp.com>"
 COPY --from=downloader /downloads/kubectl /usr/local/bin/kubectl
 COPY --from=downloader /downloads/kustomize /usr/local/bin/kustomize
 
-ENTRYPOINT ["sh"]
-
 
 # Test
 FROM runtime AS test


### PR DESCRIPTION
## Background

Resolves #9

Since alpine uses `/bin/sh` as the `CMD`, configuring `ENTRYPOINT` to `sh` is unnecessary.

### References

- [`alpine` image layers](
https://hub.docker.com/layers/alpine/library/alpine/3.16.0/images/sha256-4ff3ca91275773af45cb4b0834e12b7eb47d1c18f770a0b151381cd227f4c253?context=explore)

## Changes

Unset `ENTRYPOINT` as @flyte suggested