### PR TITLE
Fix GitHub Actions deprecation warning

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,14 +6,14 @@ on:
   workflow_dispatch: {}
 jobs:
   fetch-metadata:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     outputs:
       kubectl-version: ${{ steps.kubectl.outputs.version }}
       kustomize-version: ${{ steps.kustomize.outputs.version }}
       image-exists: ${{ steps.image-existence.outputs.exists }}
       image-tag: ${{ steps.image-existence.outputs.tag }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Prepare checking latest kubectl version
         env:
@@ -30,7 +30,7 @@ jobs:
           REPO_OWNER: ${{ github.repository_owner }}
         run: |
           if version=$(docker run ${REPO_OWNER}/kubectl-kustomize:kubectl-version); then
-            echo ::set-output name=version::$version
+            echo "version=$version" >> $GITHUB_OUTPUT
           else
             exit 1
           fi
@@ -50,7 +50,7 @@ jobs:
           REPO_OWNER: ${{ github.repository_owner }}
         run: |
           if version=$(docker run ${REPO_OWNER}/kubectl-kustomize:kustomize-version); then
-            echo ::set-output name=version::$version
+            echo "version=$version" >> $GITHUB_OUTPUT
           else
             exit 1
           fi
@@ -62,39 +62,39 @@ jobs:
           REPO_OWNER: ${{ github.repository_owner }}
         shell: bash +e {0}
         run: |
-          echo ::set-output name=tag::${IMAGE_TAG}
+          echo "tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
           result="$(DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect ${REPO_OWNER}/kubectl-kustomize:${IMAGE_TAG} 2>&1)"
           if [[ $? -eq 0 ]]; then
-            echo ::set-output name=exists::true
+            echo "exists=true" >> $GITHUB_OUTPUT
           elif [[ $result == *"no such manifest"* ]]; then
-            echo ::set-output name=exists::false
+            echo "exists=false" >> $GITHUB_OUTPUT
           else
             echo $result
             exit 1;
           fi
   release:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs:
       - fetch-metadata
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and test image
         id: build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           tags: ${{ github.repository_owner }}/kubectl-kustomize:test
@@ -109,7 +109,7 @@ jobs:
 
       - name: Push image
         if: ${{ needs.fetch-metadata.outputs.image-exists == 'false' && github.ref == 'refs/heads/master' }}
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           tags: |


### PR DESCRIPTION
## Background

Fixes some commands and jobs that have been deprecated or are scheduled to be disabled in GitHub Actions.

### Details

- [Node.js 12 actions are deprecated](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)
  - actions/checkout@v2
  - docker/setup-qemu-action@v1
  - docker/setup-buildx-action@v1
  - docker/login-action@v1
  - docker/build-push-action@v2
- [The `set-output` command is deprecated and will be disabled soon](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
- [The ubuntu-18.04 environment is deprecated](https://github.com/actions/virtual-environments/issues/6002)
 
## Test

- https://github.com/heojay/kubectl-kustomize/actions/runs/4517143374