### PR TITLE
Add docker login step on fetch-metadata job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Prepare checking latest kubectl version
         env:
           REPO_OWNER: ${{ github.repository_owner }}


### PR DESCRIPTION
## Background

The action has failed.

```
Get "https://registry-1.docker.io/v2/line/kubectl-kustomize/manifests/1.27.2-5.0.3": unauthorized: access token has insufficient scopes
```

It seems `docker manifest inspect` needs access token including `scope="repository:line/kubectl-kustomize:pull"`, (`www-authenticate` header).

```
❯ curl -v https://registry-1.docker.io/v2/line/kubectl-kustomize/manifests/1.27.2-5.0.3
*   Trying 34.205.13.154:443...
* Connected to registry-1.docker.io (34.205.13.154) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
* (304) (IN), TLS handshake, Server hello (2):
* (304) (IN), TLS handshake, Unknown (8):
* (304) (IN), TLS handshake, Certificate (11):
* (304) (IN), TLS handshake, CERT verify (15):
* (304) (IN), TLS handshake, Finished (20):
* (304) (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN, server did not agree to a protocol
* Server certificate:
*  subject: CN=*.docker.com
*  start date: May  5 00:00:00 2023 GMT
*  expire date: Jun  2 23:59:59 2024 GMT
*  subjectAltName: host "registry-1.docker.io" matched cert's "*.docker.io"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
> GET /v2/line/kubectl-kustomize/manifests/1.27.2-5.0.3 HTTP/1.1
> Host: registry-1.docker.io
> User-Agent: curl/7.79.1
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 401 Unauthorized
< content-type: application/json
< docker-distribution-api-version: registry/2.0
< www-authenticate: Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:line/kubectl-kustomize:pull"
< date: Sat, 03 Jun 2023 01:40:14 GMT
< content-length: 165
< strict-transport-security: max-age=31536000
< docker-ratelimit-source: 121.136.180.145
<
{"errors":[{"code":"UNAUTHORIZED","message":"authentication required","detail":[{"Type":"repository","Class":"","Name":"line/kubectl-kustomize","Action":"pull"}]}]}
* Connection #0 to host registry-1.docker.io left intact
```

## Changes

- Add docker login step on fetch-metadata job

## Test

- https://github.com/heojay/kubectl-kustomize/actions/runs/5161005873

## Reference

- https://docs.docker.com/registry/spec/api/#get-manifest