### PR TITLE
Replace the usage of ubuntu 20.04 to 24.04

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch: {}
 jobs:
   fetch-metadata:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       kubectl-version: ${{ steps.kubectl.outputs.version }}
       kustomize-version: ${{ steps.kustomize.outputs.version }}
@@ -79,7 +79,7 @@ jobs:
             exit 1;
           fi
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs:
       - fetch-metadata
     steps:


### PR DESCRIPTION
## Background

- [The Ubuntu 20.04 Actions runner image will begin deprecation on 2025-02-01 and will be fully unsupported by 2025-04-01](https://github.com/actions/runner-images/issues/11101)
- Since we're only using docker and echo in action, there shouldn't be any issues with the change.

## Change

- Replace the usage of ubuntu 20.04 to 24.04

## Test

- Action: https://github.com/heojay/kubectl-kustomize/actions/runs/13670920006
- Dockerhub: https://hub.docker.com/repository/docker/heojay/kubectl-kustomize/tags

<img width="894" alt="Screenshot 2025-03-05 at 16 46 25" src="https://github.com/user-attachments/assets/8124dd1d-d43c-448a-9251-d7bbb8676582" />
