### PR TITLE
 Fix missing Kubernetes release url in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG KUSTOMIZE_VERSION
 WORKDIR /downloads
 
 RUN set -ex; \
-    curl -fL https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/${TARGETOS}/${TARGETARCH}/kubectl -o kubectl && \
+    curl -fL https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/${TARGETOS}/${TARGETARCH}/kubectl -o kubectl && \
     chmod +x kubectl
 
 RUN set -ex; \


### PR DESCRIPTION
## Changes

- Update the Kubernetes release URL that was not corrected in #17.

## Test

<img width="646" height="357" alt="Screenshot 2025-11-04 at 15 14 48" src="https://github.com/user-attachments/assets/cc8827b0-a00b-43c4-8001-fd41861ea080" />

- https://github.com/heojay/kubectl-kustomize/actions/runs/19059553686
- https://hub.docker.com/r/heojay/kubectl-kustomize/tags